### PR TITLE
Fix font url bug

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,7 @@
     </style>
 
     <!-- Import Roboto, Raleway & Titillium Web from Google Web Fonts -->
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,700|Titillium+Web|Raleway' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Roboto:400,700|Titillium+Web|Raleway' rel='stylesheet' type='text/css'>
 
     {% if intro_p %}<link href="/css/introjs.min.css" rel="stylesheet"/>{% endif %}
     {% block head %}


### PR DESCRIPTION
In #201 I changed the typographical style of the website by using some fonts from [google fonts](https://www.google.com/fonts) library, but used an `http` url to import these fonts. Thus, while the fonts worked fine on my local testing server, which was not using `https` encryption, the <link> tag which imports them currently causes a cross-origin resource sharing error to be thrown on the https://research-engine.appspot.com/ website, which does use `https` encryption.